### PR TITLE
Wait for the db to be ready before applying migrations

### DIFF
--- a/MiniTwit/Program.cs
+++ b/MiniTwit/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Threading;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -110,6 +111,12 @@ if (!app.Environment.IsDevelopment())
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<MiniTwitContext>();
+
+    while (!db.Database.CanConnect())
+    {
+        Console.WriteLine("Waiting for DB connection");
+        Thread.Sleep(1000);
+    }
 
     if (db.Database.CanConnect())
     {


### PR DESCRIPTION
We must wait for the DB to be ready before we apply the migrations. This is mostly relevant in development, since in the database is always available in production. However, it is still a good check to have.

In general, the fact that this fix is needed in development also reveals that our compose file is lacking a health check on the database.